### PR TITLE
Don’t force runtime identifier on project build

### DIFF
--- a/FileHasher.CLI.Check/FileHasher.CLI.Check.csproj
+++ b/FileHasher.CLI.Check/FileHasher.CLI.Check.csproj
@@ -8,8 +8,6 @@
         <AssemblyName>check</AssemblyName>
         <Company>Krystian Duma</Company>
         <PublishSingleFile>true</PublishSingleFile>
-        <SelfContained>true</SelfContained>
-        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
         <PublishReadyToRun>true</PublishReadyToRun>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>

--- a/FileHasher.CLI.Hash/FileHasher.CLI.Hash.csproj
+++ b/FileHasher.CLI.Hash/FileHasher.CLI.Hash.csproj
@@ -8,8 +8,6 @@
         <AssemblyName>hash</AssemblyName>
         <Company>Krystian Duma</Company>
         <PublishSingleFile>true</PublishSingleFile>
-        <SelfContained>true</SelfContained>
-        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
         <PublishReadyToRun>true</PublishReadyToRun>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>

--- a/FileHasher.CLI/FileHasher.CLI.csproj
+++ b/FileHasher.CLI/FileHasher.CLI.csproj
@@ -8,8 +8,6 @@
     <AssemblyName>hasher</AssemblyName>
     <Company>Krystian Duma</Company>
     <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>true</SelfContained>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishReadyToRun>true</PublishReadyToRun>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>


### PR DESCRIPTION
Fixes #3 