### PR TITLE
Update dotnet.yml for versioning and publishing process

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -68,8 +68,10 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: get_version
       run: |
-        echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-        echo "FILE_VERSION=${GITHUB_REF#refs/tags/v}.${{ env.GIT_REVISION_NUM }}" >> $GITHUB_ENV
+        VERSION="${GITHUB_REF#refs/tags/v}"
+        FILE_VERSION="${GITHUB_REF#refs/tags/v}.${{ env.GIT_REVISION_NUM }}"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "FILE_VERSION=$FILE_VERSION" >> $GITHUB_ENV
         echo "Calculated version is: $VERSION"
         echo "Calculated file version is: $FILE_VERSION"
         


### PR DESCRIPTION
Update dotnet.yml for versioning and publishing process

Streamline the versioning and publishing workflow for the .NET application by:
- Simplifying version tags to 'v*'.
- Adding `fetch-depth` and `fetch-tags` to the checkout step.
- Introducing steps to extract and set the version from the last tag.
- Modifying `dotnet restore`, `dotnet build`, and `dotnet publish` commands to use the calculated version.
- Updating publishing commands for various platforms to include the versioning parameter.
- Adding cleanup steps to remove `.pdb` files from output directories post-publishing.